### PR TITLE
I added pagination Response, count to vehicle

### DIFF
--- a/Core/Domain/Contracts/IGenericRebository.cs
+++ b/Core/Domain/Contracts/IGenericRebository.cs
@@ -21,5 +21,7 @@ namespace Domain.Contracts
         Task AddAsync(TEntity entity);
         void Update (TEntity entity);
         void Delete (TEntity entity);
+
+        Task<int>CountAsync(ISpecification<TEntity, TKey> spec);
     }
 }

--- a/Core/Service/Specification/VehicleCountSpecification.cs
+++ b/Core/Service/Specification/VehicleCountSpecification.cs
@@ -1,0 +1,19 @@
+﻿using Domain.Models;
+using Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Service.Specification
+{
+    public class VehicleCountSpecification:BaseSpecification<Vehicle,int>
+    {
+        public VehicleCountSpecification(VehicleSpecificationParameter specvehicle):
+           base(x => string.IsNullOrEmpty(specvehicle.type) || x.VehicleType.TypeName == specvehicle.type)
+        {
+
+        }
+    }
+}

--- a/Core/Service/VehicleService.cs
+++ b/Core/Service/VehicleService.cs
@@ -22,12 +22,14 @@ namespace Service
             return result;
         }
 
-        public async Task<IEnumerable<VehicleDto>> GetAllVehiclesAsync(VehicleSpecificationParameter specvehicle)
+        public async Task<PaginationResponse<VehicleDto>> GetAllVehiclesAsync(VehicleSpecificationParameter specvehicle)
         {
             var spec= new VehicleSpecification(specvehicle);
+            var speccount = new VehicleCountSpecification(specvehicle);
+            var count = await unitOfWork.GetRebository<Vehicle, int>().CountAsync(spec);
             var vehicles = await unitOfWork.GetRebository<Vehicle, int>().GetAllAsync(spec);
             var result=mapper.Map<IEnumerable<VehicleDto>>(vehicles);
-            return result;
+            return new PaginationResponse<VehicleDto>(specvehicle, specvehicle.IndexPage, specvehicle.PageSize, count,result);
         }
 
         public async Task<VehicleDto?> GetVehicleByNumberAsync(string plateNumber)

--- a/Core/ServiceAbstraction/IVehicleService.cs
+++ b/Core/ServiceAbstraction/IVehicleService.cs
@@ -9,7 +9,7 @@ namespace ServiceAbstraction
 {
     public interface IVehicleService
     {
-        Task<IEnumerable<VehicleDto>> GetAllVehiclesAsync(VehicleSpecificationParameter specvehicle);
+        Task<PaginationResponse<VehicleDto>> GetAllVehiclesAsync(VehicleSpecificationParameter specvehicle);
         Task <VehicleDto?> GetVehicleByNumberAsync(string plateNumber);
         Task <IEnumerable<VehicleDto?>> GetVehicleOwnersAsync(string OwnerName);
         Task <IEnumerable<VehicleDto?>> GetAllVehicleBTypeAsync(string VehicleType); 

--- a/Infrastructure/Presistence/Repository/GenericRepository.cs
+++ b/Infrastructure/Presistence/Repository/GenericRepository.cs
@@ -69,6 +69,10 @@ namespace Presistence.Repository
         {
           return SpecificationEvaluation.GetQuery(dbContext.Set<TEntity>(), spec);
         }
-        
+
+        public async Task<int> CountAsync(ISpecification<TEntity, TKey> spec)
+        {
+            return await ApplicationsException(spec).CountAsync() ;
+        }
     }
 }

--- a/Shared/PaginationResponse.cs
+++ b/Shared/PaginationResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace Shared
+{
+    public class PaginationResponse<TENtity>
+    {
+        public PaginationResponse(VehicleSpecificationParameter specvehicle, int pageindex, int pagesize, int totalcount, IEnumerable<TENtity> data)
+        {
+            PageIndex = pageindex;
+            PageSize = pagesize;
+            TotalCount = totalcount;
+            Data = data;
+        }
+        public int TotalCount { get; set; }
+        public int PageSize { get; set; }
+        public int PageIndex { get; set; }
+        public IEnumerable<TENtity> Data { get; set; }
+    }
+}


### PR DESCRIPTION
I added a pagination response so that when I get a lot of data, I can send part of it and not all of it at once, because I can't send all of the data at once to the front end, and that would take a toll on the API and ruin the front end's performance and the user data on several pages.
I added a count to count the number of cars and I made it a separate class so that if I wanted to use it for something else, I could inherit from it.