### PR TITLE
Refactoring main function and middleware

### DIFF
--- a/CPMS/Extantion/Extantion.cs
+++ b/CPMS/Extantion/Extantion.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Service;
+using ServiceAbstraction;
+using Microsoft.OpenApi.Services;
+using Shared.ErrorModels;
+using Presistence;
+using CPMS.MiddleWare;
+using Domain;
+
+namespace CPMS.Extantion
+{
+    public static class Extantion
+    { 
+        public static IServiceCollection Register (this IServiceCollection services,IConfiguration configuration)
+        {
+            services.AddControllers();
+            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+           services.AddEndpointsApiExplorer();
+           services.AddSwaggerGen();
+          
+           services.AddInfrastructure(configuration);
+         
+           services.AddScoped<IServiceManager, ServiceManager>();
+           services.AddAutoMapper(typeof(MappingAssemblyReference).Assembly);
+         
+           services.Configure<ApiBehaviorOptions>(options =>
+            {
+                options.InvalidModelStateResponseFactory = context =>
+                {
+                    var errors = context.ModelState
+                        .Where(x => x.Value.Errors.Any())
+                        .Select(x => new ValidationError
+                        {
+                            field = x.Key,
+                            errors = x.Value.Errors.Select(e => e.ErrorMessage)
+                        }).ToList();
+
+                    var response = new ValidationErrorResponse
+                    {
+                        Errors = errors
+                    };
+
+                    return new BadRequestObjectResult(response);
+                };
+            });
+            return services;
+        }
+
+        public static async Task<WebApplication> configurationmiddleware(this WebApplication app)
+        {
+            // Configure the HTTP request pipeline.
+            if (app.Environment.IsDevelopment())
+            {
+                app.UseSwagger();
+                app.UseSwaggerUI();
+            }
+            using var scope = app.Services.CreateScope();
+            var dbintilaizer = scope.ServiceProvider.GetService<IDbIntilaizer>();
+            await dbintilaizer.IntilaizerAsync();
+
+            app.UseHttpsRedirection();
+
+            app.UseAuthorization();
+
+            app.UseMiddleware<GlobalErrorMiddleWare>();
+
+            app.MapControllers();
+            return app;
+        }
+    }
+}

--- a/CPMS/Program.cs
+++ b/CPMS/Program.cs
@@ -1,3 +1,4 @@
+using CPMS.Extantion;
 using CPMS.MiddleWare;
 using Domain;
 using Domain.Contracts;
@@ -20,62 +21,12 @@ namespace CPMS
 
             // Add services to the container.
 
-            builder.Services.AddControllers();
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
-            builder.Services.AddDbContext<CPMSDbContext>(option =>
-            {
-                option.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
-            });
-
-            builder.Services.AddScoped<IDbIntilaizer, DbIntilaizer>();
-
-            builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
-            builder.Services.AddScoped<IServiceManager, ServiceManager>();
-            builder.Services.AddAutoMapper(typeof(MappingAssemblyReference).Assembly);
-
-            builder.Services.Configure<ApiBehaviorOptions>(options =>
-            {
-                options.InvalidModelStateResponseFactory = context =>
-                {
-                    var errors = context.ModelState
-                        .Where(x => x.Value.Errors.Any())
-                        .Select(x => new ValidationError
-                        {
-                            field = x.Key,
-                            errors = x.Value.Errors.Select(e => e.ErrorMessage)
-                        }).ToList();
-
-                    var response = new ValidationErrorResponse
-                    {
-                        Errors = errors
-                    };
-
-                    return new BadRequestObjectResult(response);
-                };
-            });
+            builder.Services.Register(builder.Configuration);
 
 
             var app = builder.Build();
 
-            // Configure the HTTP request pipeline.
-            if (app.Environment.IsDevelopment())
-            {
-                app.UseSwagger();
-                app.UseSwaggerUI();
-            }
-            using var scope = app.Services.CreateScope();
-            var dbintilaizer = scope.ServiceProvider.GetService<IDbIntilaizer>();
-            await dbintilaizer.IntilaizerAsync();
-
-            app.UseHttpsRedirection();
-
-            app.UseAuthorization();
-
-            app.UseMiddleware<GlobalErrorMiddleWare>();
-
-            app.MapControllers();
+           await app.configurationmiddleware();
 
             app.Run();
         }

--- a/Core/Service/ApplicationServices.cs
+++ b/Core/Service/ApplicationServices.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using ServiceAbstraction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+namespace Service
+{
+    public static class ApplicationServices
+    {
+        public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+        {
+            services.AddScoped<IServiceManager, ServiceManager>();
+            services.AddAutoMapper(typeof(MappingAssemblyReference).Assembly);
+
+            return services;
+        }
+    }
+}

--- a/Core/Service/Service.csproj
+++ b/Core/Service/Service.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Infrastructure/Presistence/InfrastructureServices.cs
+++ b/Infrastructure/Presistence/InfrastructureServices.cs
@@ -1,0 +1,31 @@
+﻿using Domain;
+using Domain.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Presistence
+{
+    public static class InfrastructureServices
+    {
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddDbContext<CPMSDbContext>(option =>
+            {
+                option.UseSqlServer(configuration.GetConnectionString("DefaultConnection"));
+            });
+
+            services.AddScoped<IDbIntilaizer, DbIntilaizer>();
+
+            services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Because my main will keep getting bigger and that's not the best thing, the solution is to make it look good and at the same time understandable for the reader, so we divided it into two parts: builder, app.
I created a class and made it static and made it an extension for the IServiceCollection.
These included UnitOfWork, DbInitilizer, and DbContext.
As for Automapper and IServiceManger, they are related to the Service layer, so we'll create a funnel in the Service layer.
I'll create a class called Extension that contains all the builders.
We'll create a funnel in all the app.