### PR TITLE
I used the Mailkit method in the ForgetPassord

### DIFF
--- a/CPMS/appsettings.json
+++ b/CPMS/appsettings.json
@@ -20,5 +20,12 @@
   "StripeSetting": {
     "SecreteKey": "sk_test_51N3tY2qqqSDH3mXH3b1Yk1"
   },
+  "MailSetting": {
+    "Email": "moyassin2004522@gmail.com",
+    "DisplayName": "CPMS Support",
+    "Password": "moyassin@12345",
+    "Host": "smtp.gmail.com",
+    "Port": 587
+  },
   "AllowedHosts": "*"
 }

--- a/Core/Domain/Models/MailSetting.cs
+++ b/Core/Domain/Models/MailSetting.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Models
+{
+    public class MailSetting
+    {
+        public string Email { get; set; }
+        public string DisplayName { get; set; }
+        public string Password { get; set; }
+        public string Host { get; set; }
+        public int Port { get; set; }
+    }
+}

--- a/Core/Service/Service.csproj
+++ b/Core/Service/Service.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Stripe.net" Version="48.6.0-beta.1" />

--- a/Core/ServiceAbstraction/IAuthservice.cs
+++ b/Core/ServiceAbstraction/IAuthservice.cs
@@ -1,4 +1,5 @@
-﻿using Domain.Models.Identity;
+﻿using Domain.Models;
+using Domain.Models.Identity;
 using Shared;
 using System;
 using System.Collections.Generic;
@@ -19,5 +20,7 @@ namespace ServiceAbstraction
         Task<List<InvoiceDto>> GetUserInvoicesAsync(string email);
         Task<UserResultDto>LogoutAsync();
         Task<string> ResetePassword(ResetePasswordDto Dto);
+        Task SendEmailAsync(Email email);
     }
+
 }

--- a/Infrastructure/Presentation/AuthController.cs
+++ b/Infrastructure/Presentation/AuthController.cs
@@ -58,7 +58,7 @@ namespace Presentation
                 Body = $"Click the link to reset your password: {url}"
             };
 
-            EmailSetting.SendEmail(emailRequest);
+           serviceManager.AuthService.SendEmailAsync(emailRequest);
 
             return Ok("Reset link has been sent to your email");
         }

--- a/Infrastructure/Presentation/InvoiceController.cs
+++ b/Infrastructure/Presentation/InvoiceController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceAbstraction;
 using Shared;
@@ -13,6 +14,7 @@ namespace Presentation
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class InvoiceController(IServiceManager serviceManager):ControllerBase
     {
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PaginationResponse<InvoiceDto, InvoiceSpecificationParameter>))]

--- a/Infrastructure/Presentation/ParkingRecordController.cs
+++ b/Infrastructure/Presentation/ParkingRecordController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceAbstraction;
 using Shared;
@@ -13,6 +14,7 @@ namespace Presentation
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class ParkingRecordController(IServiceManager serviceManager):ControllerBase
     {
         [HttpGet("platnumber")]

--- a/Infrastructure/Presentation/PaymentController.cs
+++ b/Infrastructure/Presentation/PaymentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using ServiceAbstraction;
 using System;
 using System.Collections.Generic;
@@ -10,6 +11,7 @@ namespace Presentation
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class PaymentController(IServiceManager serviceManager): ControllerBase
     {
 

--- a/Infrastructure/Presentation/VehicleController.cs
+++ b/Infrastructure/Presentation/VehicleController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceAbstraction;
 using Shared;
@@ -12,7 +13,8 @@ using System.Threading.Tasks;
 namespace Presentation
 {
     [ApiController]
-    [Route("api/[controller]")] 
+    [Route("api/[controller]")]
+    [Authorize]
     public class VehicleController(IServiceManager serviceManager):ControllerBase
     {
         [HttpGet]

--- a/Infrastructure/Presentation/ZoneController.cs
+++ b/Infrastructure/Presentation/ZoneController.cs
@@ -1,5 +1,6 @@
 ﻿using Domain.Exceptions;
 using Domain.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceAbstraction;
@@ -15,6 +16,7 @@ namespace Presentation
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class ZoneController(IServiceManager serviceManager):ControllerBase
     {
         [HttpGet]

--- a/Infrastructure/Presistence/InfrastructureServices.cs
+++ b/Infrastructure/Presistence/InfrastructureServices.cs
@@ -1,6 +1,8 @@
 ﻿using Domain;
 using Domain.Contracts;
+using Domain.Models;
 using Domain.Models.Identity;
+using MailKit;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -35,6 +37,8 @@ namespace Presistence
             services.AddSingleton<IConnectionMultiplexer>(sp =>
             ConnectionMultiplexer.Connect(configuration.GetConnectionString("RedisConnection")));
 
+            services.Configure<MailSetting>(configuration.GetSection(nameof(MailSetting)));
+            services.AddScoped<IMailService, MailService>();
 
             services.AddIdentity<AppUsers, IdentityRole>()
     .AddEntityFrameworkStores<CPMS_Identity>()


### PR DESCRIPTION
I used the Mailkit method in the ForgetPassord section via send email, and what made me change to SMPT is that Mailkit is a built-in library inside .NET, and this is better in terms of performance because the package is downloaded and I have it, and it also depends on the old method, which is SMPT.