### PR TITLE
I used the Mailkit method in the ForgetPassord section

### DIFF
--- a/Core/Service/Authservice.cs
+++ b/Core/Service/Authservice.cs
@@ -15,7 +15,7 @@ using System.Text;
 
 namespace Service
 {
-    public class Authservice(UserManager<AppUsers>userManager,IOptions<JWTOptions>options,IMapper mapper, SignInManager<AppUsers> signInManager, IOptions<MailSetting>options1) : IAuthservice
+    public class Authservice(UserManager<AppUsers>userManager,IOptions<JWTOptions>options,IMapper mapper, SignInManager<AppUsers> signInManager) : IAuthservice
     {
         public async Task<bool> CheckEmailExistAsync(string email)
         {
@@ -192,19 +192,5 @@ namespace Service
             return "Password has been reset successfully.";
         }
 
-        public async Task SendEmailAsync(Email email)
-        {
-            var mail=new MimeMessage();
-            mail.Subject = email.Subject;
-            mail.From.Add(new MailboxAddress(options1.Value.DisplayName, options1.Value.Email));
-            mail.To.Add(MailboxAddress.Parse(email.To));
-            var builder = new BodyBuilder();
-            builder.HtmlBody = email.Body;
-            mail.Body = builder.ToMessageBody();
-            using var smtp=new MailKit.Net.Smtp.SmtpClient();
-            smtp.Connect(options1.Value.Host, options1.Value.Port, MailKit.Security.SecureSocketOptions.StartTls);
-            smtp.Authenticate(options1.Value.Email, options1.Value.Password);
-            smtp.Send(mail);
-        }
     }
 }

--- a/Core/Service/MailServices.cs
+++ b/Core/Service/MailServices.cs
@@ -1,0 +1,30 @@
+﻿using Domain.Models;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using ServiceAbstraction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Service
+{
+    public class MailServices(IOptions<MailSetting> options1) : IMailServices
+    {
+        public async Task SendEmailAsync(Email email)
+        {
+            var mail = new MimeMessage();
+            mail.Subject = email.Subject;
+            mail.From.Add(new MailboxAddress(options1.Value.DisplayName, options1.Value.Email));
+            mail.To.Add(MailboxAddress.Parse(email.To));
+            var builder = new BodyBuilder();
+            builder.HtmlBody = email.Body;
+            mail.Body = builder.ToMessageBody();
+            using var smtp = new MailKit.Net.Smtp.SmtpClient();
+            smtp.Connect(options1.Value.Host, options1.Value.Port, MailKit.Security.SecureSocketOptions.StartTls);
+            smtp.Authenticate(options1.Value.Email, options1.Value.Password);
+            smtp.Send(mail);
+        }
+    }
+}

--- a/Core/Service/ServiceManager.cs
+++ b/Core/Service/ServiceManager.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Domain.Contracts;
+using Domain.Models;
 using Domain.Models.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
@@ -9,7 +10,7 @@ using Shared;
 
 namespace Service
 {
-    public class ServiceManager(IUnitOfWork unitOfWork,UserManager<AppUsers>userManagers ,IMapper mapper,ICacheRepository repository,IConfiguration configuration,IOptions<JWTOptions>options,SignInManager<AppUsers>signInManager,RoleManager<IdentityRole>roleManager) : IServiceManager
+    public class ServiceManager(IUnitOfWork unitOfWork,UserManager<AppUsers>userManagers ,IMapper mapper,ICacheRepository repository,IConfiguration configuration,IOptions<JWTOptions>options,SignInManager<AppUsers>signInManager,RoleManager<IdentityRole>roleManager,IOptions<MailSetting>options1) : IServiceManager
     {
         public IVehicleService<VehicleSpecificationParameter, VehicleDto> VehicleService { get; }= new VehicleService(unitOfWork, mapper);
         public ICacheService CacheService { get; } = new CacheServices(repository);
@@ -26,5 +27,7 @@ namespace Service
         public IRoleServices RoleService { get; }=new RoleServices(roleManager,mapper);
 
         public ITariffServices TariffService => throw new NotImplementedException();
+
+        public IMailServices MailServices { get; } =new MailServices(options1);
     }
 }

--- a/Core/ServiceAbstraction/IAuthservice.cs
+++ b/Core/ServiceAbstraction/IAuthservice.cs
@@ -20,7 +20,7 @@ namespace ServiceAbstraction
         Task<List<InvoiceDto>> GetUserInvoicesAsync(string email);
         Task<UserResultDto>LogoutAsync();
         Task<string> ResetePassword(ResetePasswordDto Dto);
-        Task SendEmailAsync(Email email);
+        
     }
 
 }

--- a/Core/ServiceAbstraction/IMailServices.cs
+++ b/Core/ServiceAbstraction/IMailServices.cs
@@ -1,0 +1,14 @@
+﻿using Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ServiceAbstraction
+{
+    public interface IMailServices
+    {
+        Task SendEmailAsync(Email email);
+    }
+}

--- a/Core/ServiceAbstraction/IServiceManager.cs
+++ b/Core/ServiceAbstraction/IServiceManager.cs
@@ -18,5 +18,6 @@ namespace ServiceAbstraction
         IPamentServices PaymentService { get; }
         IRoleServices RoleService { get; }
         ITariffServices TariffService { get; }
+        IMailServices MailServices { get; }
     }
 }

--- a/Infrastructure/Presentation/AuthController.cs
+++ b/Infrastructure/Presentation/AuthController.cs
@@ -58,7 +58,7 @@ namespace Presentation
                 Body = $"Click the link to reset your password: {url}"
             };
 
-           serviceManager.AuthService.SendEmailAsync(emailRequest);
+           serviceManager.MailServices.SendEmailAsync(emailRequest);
 
             return Ok("Reset link has been sent to your email");
         }

--- a/Infrastructure/Presistence/InfrastructureServices.cs
+++ b/Infrastructure/Presistence/InfrastructureServices.cs
@@ -37,8 +37,7 @@ namespace Presistence
             services.AddSingleton<IConnectionMultiplexer>(sp =>
             ConnectionMultiplexer.Connect(configuration.GetConnectionString("RedisConnection")));
 
-            services.Configure<MailSetting>(configuration.GetSection(nameof(MailSetting)));
-            services.AddScoped<IMailService, MailService>();
+           
 
             services.AddIdentity<AppUsers, IdentityRole>()
     .AddEntityFrameworkStores<CPMS_Identity>()


### PR DESCRIPTION
I used the Mailkit method in the ForgetPassord section via send email, and what made me change to SMPT is that Mailkit is a built-in library inside .NET, and this is better in terms of performance because the package is downloaded and I have it, and it also depends on the old method, which is SMPT.